### PR TITLE
置換修正・文字サイズ調整方法変更 

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
             <input type="checkbox" id="spacenewline" checked >スペースで改行する</input>
             <input type="checkbox" id="doublenewline" checked>改行数を固定する(空白1行)</input>
         </div>
-        <textarea id="otayori_adjusted" rows="auto"></textarea>
+        <textarea id="otayori_adjusted" placeholder="調整した文章" rows="auto"></textarea>
     </div>
     <script src="./script.js">
     </script>

--- a/index.html
+++ b/index.html
@@ -20,8 +20,8 @@
         <div>
             <button id="adjust" style="font-weight:bold;">調整</button>
             <button id="clear"     >クリア</button>
-            文字サイズ<input type="number" id="fontsize" step="2" value="16" max="50" min="6">
-            行間<input type="number" id="linespace" step="0.1" value="0.5" max="2" min="0">行
+            文字サイズ<input type="number" id="fontsize" step="2" value="20" max="50" min="6">
+            行間<input type="number" id="linespace" step="0.1" value="0" max="2" min="0">行
             <button id="example"   >例文</button>
         </div>
         <div>

--- a/index.html
+++ b/index.html
@@ -19,12 +19,10 @@
         <textarea id="otayori_raw" placeholder="入力"></textarea>
         <div>
             <button id="adjust" style="font-weight:bold;">調整</button>
-            <button id="zoomin"    >拡大</button>
-            <button id="zoomout"   >縮小</button>
             <button id="clear"     >クリア</button>
-            <button id="initialize">文字サイズ初期化</button>
-            <button id="example"   >例文</button>
+            文字サイズ<input type="number" id="fontsize" step="2" value="16" max="50" min="6">
             行間<input type="number" id="linespace" step="0.1" value="0.5" max="2" min="0">行
+            <button id="example"   >例文</button>
         </div>
         <div>
             <input type="checkbox" id="kutennewline" checked >「。」で改行する</input>

--- a/script.js
+++ b/script.js
@@ -16,7 +16,7 @@ function cleanup(otayori) {
   // 「。」を「。改行」にする
   // 「。 改行」の場合スペースを消去
   if(document.getElementById("kutennewline").checked) {
-    otayori = otayori.replace(/(。+)([ 　]*)(?!$)/mg, "$1\n");
+    otayori = otayori.replace(/(。+[」)）]?)([ 　]*)(?!$)/mg, "$1\n");
   }
 
   // 「。」の無い行末に「。」を追加する

--- a/script.js
+++ b/script.js
@@ -45,16 +45,9 @@ function adjust() {
   document.getElementById("otayori_adjusted").style.height = `${scrollHeight}px`;
 }
 
-function zoomin(){
-  fontSize = Math.min(fontSize+5, 100);
+function fontsize(){
+  fontSize = Number(document.getElementById("fontsize").value);
   document.getElementById("otayori_adjusted").style.fontSize = `${fontSize}px`;
-  adjust();
-}
-
-function zoomout(){
-  fontSize = Math.max(fontSize-5, 1);
-  document.getElementById("otayori_adjusted").style.fontSize = `${fontSize}px`;
-  adjust();
 }
 
 function clear() {
@@ -62,10 +55,6 @@ function clear() {
   document.getElementById("otayori_adjusted").value = "";
 }
 
-function initialize(){
-  fontSize = 16;
-  document.getElementById("otayori_adjusted").style.fontSize = `${fontSize}px`;
-}
 
 function example() {
   let sampletxt =
@@ -78,12 +67,10 @@ function example() {
 
 let fontSize = 16;
 document.getElementById("adjust").addEventListener("click", adjust);
-document.getElementById("zoomin").addEventListener("click", zoomin);
-document.getElementById("zoomout").addEventListener("click", zoomout);
 document.getElementById("clear").addEventListener("click", clear);
-document.getElementById("initialize").addEventListener("click", initialize);
 document.getElementById("example").addEventListener("click", example);
 document.getElementById("linespace").addEventListener("input", linespace);
+document.getElementById("fontsize").addEventListener("input", fontsize);
 document.getElementById("kutennewline").addEventListener("change", adjust);
 document.getElementById("addkuten").addEventListener("change", adjust);
 document.getElementById("spacenewline").addEventListener("change", adjust);

--- a/script.js
+++ b/script.js
@@ -13,17 +13,16 @@ function cleanup(otayori) {
     otayori = otayori.replace(/([ 　]+)/g, "\n");
   }
 
-  // 「。」を「。改行」にする(既に「。改行」は否定的先読みで無視)
+  // 「。」を「。改行」にする
   // 「。 改行」の場合スペースを消去
   if(document.getElementById("kutennewline").checked) {
-    otayori = otayori.replace(/(。+)([ 　]*)(?!\n)/g, "$1\n");
+    otayori = otayori.replace(/(。+)([ 　]*)(?!$)/mg, "$1\n");
   }
 
   // 「。」の無い行末に「。」を追加する
   // 「エクスクラメーション」「クエスチョン」「括弧閉じ」「、」の場合は無視する
   if(document.getElementById("addkuten").checked) {
-    otayori = otayori.replace(/([^。!！?？、,.」\n])([\n])/g, "$1。$2");
-    otayori = otayori.replace(/([^。!！?？、,.」\n])$/g, "$1。");
+    otayori = otayori.replace(/([^。!！?？、,.」])$/mg, "$1。");
   }
 
   // 改行数を固定する(空白1行)

--- a/script.js
+++ b/script.js
@@ -16,13 +16,13 @@ function cleanup(otayori) {
   // 「。」を「。改行」にする
   // 「。 改行」の場合スペースを消去
   if(document.getElementById("kutennewline").checked) {
-    otayori = otayori.replace(/(。+[」)）]?)([ 　]*)(?!$)/mg, "$1\n");
+    otayori = otayori.replace(/(。+[」\)）]?)([ 　]*)(?!$)/mg, "$1\n");
   }
 
   // 「。」の無い行末に「。」を追加する
   // 「エクスクラメーション」「クエスチョン」「括弧閉じ」「、」の場合は無視する
   if(document.getElementById("addkuten").checked) {
-    otayori = otayori.replace(/([^。!！?？、,.」）)])$/mg, "$1。");
+    otayori = otayori.replace(/([^。!！?？、,.」）\)])$/mg, "$1。");
   }
 
   // 改行数を固定する(空白1行)

--- a/script.js
+++ b/script.js
@@ -22,7 +22,7 @@ function cleanup(otayori) {
   // 「。」の無い行末に「。」を追加する
   // 「エクスクラメーション」「クエスチョン」「括弧閉じ」「、」の場合は無視する
   if(document.getElementById("addkuten").checked) {
-    otayori = otayori.replace(/([^。!！?？、,.」])$/mg, "$1。");
+    otayori = otayori.replace(/([^。!！?？、,.」）)])$/mg, "$1。");
   }
 
   // 改行数を固定する(空白1行)

--- a/style.css
+++ b/style.css
@@ -17,13 +17,13 @@ textarea {
     margin: 3px;
     padding: 3px;
     font-size: 100%;
-    font-size: 16px;
+    font-size: 20px;
     resize: vertical;
 }
 #otayori_adjusted{
   font-family: "ＭＳ ゴシック",sans-serif;
   color: #000;
-  line-height:1.5em;
+  line-height:1em;
 }
 button {
     margin: auto;

--- a/style.css
+++ b/style.css
@@ -17,12 +17,13 @@ textarea {
     margin: 3px;
     padding: 3px;
     font-size: 100%;
-    font-size: 20px;
+    font-size: 16px;
     resize: vertical;
 }
 #otayori_adjusted{
   font-family: "ＭＳ ゴシック",sans-serif;
   color: #000;
+  font-size: 20px;
   line-height:1em;
 }
 button {


### PR DESCRIPTION
置換挙動の修正

"「。」を行末に追加"の例外に)と）を追加
"。で改行"について、"。」"等のパターンでは括弧閉じの後に改行するように変更
文字サイズ調整を数値入力に変更

デフォルト値を配信で使用されていた設定に変更(20px 行間0(line-height:1em))