### PR TITLE
空行にも「。」が追加される問題を修正

### DIFF
--- a/script.js
+++ b/script.js
@@ -19,8 +19,9 @@ function format(otayori) {
 
   // 「。」の無い行末に「。」を追加する
   // 「エクスクラメーション」「クエスチョン」「括弧閉じ」「、」の場合は無視する
+  // 後読みで行末の手前に文字があり(=空行でない)、かつその文字が上記例外文字でない場合に「。」追加
   if(document.getElementById("addkuten").checked) {
-    otayori = otayori.replace(/([^。!！?？、,.」）\)])$/mg, "$1。");
+    otayori = otayori.replace(/(?<=.)(?<=[^。!！?？、,.」）\)])$/mg, "。");
   }
 
   // 改行数を固定する(空白1行)


### PR DESCRIPTION
「。」の無い行末に「。」を追加する置換処理の実装を後読みを使ったものに変更し、最後の文字が「エクスクラメーション」等だった場合に加え空行だった場合にも「。」を追加する処理を行わないようにしました。