### PR TITLE
textareaのfont-size指定が重複しているので片方を削除

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,7 +16,6 @@ textarea {
     width: 100%;
     margin: 3px;
     padding: 0.4em;
-    font-size: 100%;
     font-size: 16px;
     resize: none;
 }


### PR DESCRIPTION
`textarea`の`font-size`指定が`100%`と`16px`で重複しているので、先に書かれている(上書きされている)ほうを削除しました。