### PR TITLE
文頭の空白のみ削除するように変更

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,7 +4,7 @@ function format(otayori) {
   otayori = String(otayori);
 
   // 文頭(行頭ではなく文全体の頭)のスペース/改行を削除
-  otayori = otayori.trim();
+  otayori = otayori.trimStart();
 
   // 「 」を「改行」にする(英語のスペースは改行しない)
   if(document.getElementById("spacenewline").checked) {


### PR DESCRIPTION
ソースコード中のコメントには
> 文頭(行頭ではなく文全体の頭)のスペース/改行を削除

と書かれていますが、現状の実装では文末の空白も削除されています。

コメントが正しいのであれば`trimStart()`メソッドに変更する必要がありますし、現状の実装が正しいのであればコメントを修正すべきです。