### PR TITLE
splitを使ったカッコ内での"。"後改行の無効化

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,8 +14,22 @@ function format(otayori) {
   // 「。」を「。改行」にする
   // 「。 改行」の場合スペースを消去
   if(document.getElementById("kutennewline").checked) {
-    otayori = otayori.replace(/(。+[」)）]?)([ 　]*)(?!$)/mg, "$1\n");
+    //左カッコの左、右カッコの右で区切る
+    splitted_otayori = otayori.split(/(?=[(「（])|(?<=[)」）])/g);
+    for(let i=0;i<splitted_otayori.length;i++){
+      if(/^[(「（](.|\n)*[」)）]$/.test(splitted_otayori[i])){
+        //両端が左カッコと右カッコなら文中では改行せず、末尾が"。」"なら最後に改行する
+        splitted_otayori[i] = splitted_otayori[i].replace(/(。+[」)）])([ 　]*)$/g, "$1\n");
+      }else{
+        //それ以外は"。"で改行する
+        splitted_otayori[i] = splitted_otayori[i].replace(/(。)([ 　]*)/mg, "$1\n");
+      }
+    }
+    //区切られたお便りを結合する
+    otayori = splitted_otayori.join("");
   }
+  //文末の改行を削除する
+  otayori = otayori.replace(/\n+$/g, "");
 
   // 「。」の無い行末に「。」を追加する
   // 「エクスクラメーション」「クエスチョン」「括弧閉じ」「、」の場合は無視する

--- a/script.js
+++ b/script.js
@@ -14,15 +14,16 @@ function format(otayori) {
   // 「。」を「。改行」にする
   // 「。 改行」の場合スペースを消去
   if(document.getElementById("kutennewline").checked) {
-    //左カッコの左、右カッコの右で区切る
-    splitted_otayori = otayori.split(/(?=[(「（])|(?<=[)」）])/g);
+    //左カッコの左、右カッコの右で区切る(改行が右カッコに続く場合は改行後に区切る)
+    splitted_otayori = otayori.split(/(?=[(「（])|(?<=[)」）]\n*)(?!\n)/g);
+    console.log(splitted_otayori)
     for(let i=0;i<splitted_otayori.length;i++){
-      if(/^[(「（](.|\n)*[」)）]$/.test(splitted_otayori[i])){
+      if(/^[(「（](.|\n)*[」)）]\n*$/.test(splitted_otayori[i])){
         //両端が左カッコと右カッコなら文中では改行せず、末尾が"。」"なら最後に改行する
         splitted_otayori[i] = splitted_otayori[i].replace(/(。+[」)）])([ 　]*)$/g, "$1\n");
       }else{
         //それ以外は"。"で改行する
-        splitted_otayori[i] = splitted_otayori[i].replace(/(。)([ 　]*)/mg, "$1\n");
+        splitted_otayori[i] = splitted_otayori[i].replace(/(。)([ 　]*)(?!\n)/mg, "$1\n");
       }
     }
     //区切られたお便りを結合する


### PR DESCRIPTION
カッコ内改行の無効化(#6)について、@norihitoishidaさんのアドバイスを基に別の実装を行いました。
こちらの方が(#17)よりも可読性が高くて良いかと思います。