### PR TITLE
fontsize の min と number の min の値調整

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
         <textarea id="otayori_raw" placeholder="入力" spellcheck="false"></textarea>
         <div>
             <button id="clear"     >クリア</button>
-            <label>文字サイズ<input type="number" id="fontsize" step="2" value="20" max="50" min="6"></label>
-            <label>行間<input type="number" id="linespace" step="0.1" value="0.7" max="2" min="-1">行</label>
+            <label>文字サイズ<input type="number" id="fontsize" step="2" value="20" max="50" min="10"></label>
+            <label>行間<input type="number" id="linespace" step="0.1" value="0.7" max="2" min="0">行</label>
             <button id="example"   >例文</button>
         </div>
         <div>


### PR DESCRIPTION
・fontsizeのmin
　　Chromeの最小値が10pxらしいので、10未満にならないように最小値の設定
・numberのmin
　　行間設定が最小で-1になるようになっていたので、minを0に変更