### PR TITLE
スクロールバーを常に表示するように変更

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,7 @@
+body {
+    overflow-y: scroll;
+}
+
 .header {
     text-align: center;
     font-size: 16px;


### PR DESCRIPTION
お便りの長さによってスクロールバーの有無が変わると中央寄せの要素が位置が変わるため、配信時には画面キャプチャを都度修正する必要がありました。
(今のところスクロールバーが出るほどの長文お便りはありませんでしたが)
そこで、スクロールバーを常に表示するように変更することでこの問題を解消しました。