### PR TITLE
調整後文章のテキストボックスでもspellcheckを無効化

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
             <input type="checkbox" id="spacenewline" checked ><label for="spacenewline">スペースで改行する</label>
             <input type="checkbox" id="doublenewline" checked><label for="doublenewline">改行数を固定する</label>
         </div>
-        <textarea id="otayori_adjusted" placeholder="調整した文章"></textarea>
+        <textarea id="otayori_adjusted" placeholder="調整した文章" spellcheck="false"></textarea>
     </div>
     <script src="./script.js">
     </script>


### PR DESCRIPTION
昨日の配信にてテキストボックス上の文章にスペルチェックの赤線が入っていた(参考:https://youtu.be/8NQngzFTYu4?t=516 )ので、入力欄と同様にspellcheck=falseを入れて修正しました。
